### PR TITLE
Separate notary and goatary setup procedures

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,10 @@
 
 ## Building opentxs with python bindings
 
-See the [build instructions](https://github.com/monetas/opentxs), but use the following extra options for cmake. Change the paths below to match your system if necessary.
+See the
+[build instructions](https://github.com/Open-Transactions/opentxs),
+but use the following extra options for cmake. Change the paths below
+to match your system if necessary.
 
 ```shell
 cmake .. \
@@ -34,7 +37,11 @@ virtualenv -p `which python3` ~/.virtualenvs/opentxs
 ```
 
 
-Then edit `~/.virtualenvs/opentxs/bin/activate` and add the following environment variables at the bottom (so that you don't have to keep setting them each time you use a new shell). Edit the paths to reflect where you installed opentxs libraries, and where you cloned this repository.
+Then edit `~/.virtualenvs/opentxs/bin/activate` and add the following
+environment variables at the bottom (so that you don't have to keep
+setting them each time you use a new shell). Edit the paths to reflect
+where you installed opentxs libraries, and where you cloned this
+repository.
 
 ```shell
 export PYTHONPATH=/usr/local/lib64/python3.3/site-packages/:~/workspace/opentxs-tests/python3
@@ -54,16 +61,28 @@ pip install -Ur requirements.txt
 
 ## Running the tests
 
-**Note:** these tests will destroy any running `opentxs-notary` processes and all the data in `~/.ot`. If you need any of your existing data, back it up first.
+**Note:** these tests will destroy any running `opentxs-notary` or
+  `notary` processes, and all the data in `~/.ot`. If you need any of
+  your existing data, back it up first.
 
 ```shell
 cd ~/workspace/opentxs-tests/python3
 ./runtests.py
 ```
 
+## Running against the new (Golang) notary
+
+```shell
+cd ~/workspace/opentxs-tests/python3
+# selects the new notary version and only tests that currently work with it
+./runtests.py --notary-version 1 -m goatary
+```
+
 ## Logs
 
-The `opentxs-notary` stdout will be redirected to `opentxs-notary.log`.
+The `opentxs-notary` stdout will be redirected to
+`opentxs-notary.log`. `notary` stdout will go to
+`opentxs-goatary.log`.
 
 
 

--- a/python3/conftest.py
+++ b/python3/conftest.py
@@ -1,0 +1,26 @@
+import pytest
+import pyopentxs
+
+
+def pytest_addoption(parser):
+    parser.addoption("--notary-version", type=int, default=0,
+                     help="Version of opentxs notary being tested. 0=c++, 1=goatary")
+
+
+@pytest.yield_fixture(autouse=True, scope="session")
+def notary_setup(pytestconfig):
+    ver = pytestconfig.getoption("--notary-version")
+    if ver == 1:
+        # goatary
+        from pyopentxs import goatary
+        contract_dir = goatary.create_server_contract()
+        pyopentxs.create_fresh_wallet()
+        goatary.start_notary(contract_dir)
+        goatary.add_server_contract(contract_dir)
+        yield
+        pyopentxs.cleanup()
+    else:
+        from pyopentxs import notary
+        notary.fresh_setup()
+        yield
+        pyopentxs.cleanup()

--- a/python3/pyopentxs/__init__.py
+++ b/python3/pyopentxs/__init__.py
@@ -2,7 +2,9 @@ import opentxs
 from contextlib import closing
 import os
 import sys
-
+import psutil
+import shutil
+import pyopentxs
 
 # OTME = OpenTransactions MadeEasy
 otme = opentxs.OT_ME()
@@ -88,3 +90,20 @@ def init():
 
 def cleanup():
     opentxs.OTAPI_Wrap_AppCleanup()
+
+
+def killall(process_name):
+    for proc in psutil.process_iter():
+        if proc.name() == process_name:
+            proc.kill()
+            psutil.wait_procs([proc], timeout=10)
+    print("killed all %s" % process_name)
+
+
+def create_fresh_wallet():
+    # this creates fresh data in OT client data dir
+    if os.path.exists(pyopentxs.config_dir):
+        shutil.rmtree(pyopentxs.config_dir)
+
+    # create a client wallet just for making the server contract
+    os.system("opentxs --dummy-passphrase changepw")

--- a/python3/pyopentxs/client.py
+++ b/python3/pyopentxs/client.py
@@ -1,0 +1,5 @@
+import pyopentxs
+import os
+import shutil
+
+

--- a/python3/pyopentxs/goatary.py
+++ b/python3/pyopentxs/goatary.py
@@ -1,0 +1,43 @@
+import subprocess
+import tempfile
+import os
+import opentxs
+import pyopentxs
+from pyopentxs import server
+
+
+def add_server_contract(contract_dir):
+    pyopentxs.init()
+    decoded_signed_contract = open(contract_dir + "/contract.otc").read()
+    server_contract_id = open(contract_dir + "/notaryID").read().strip()
+    opentxs.OTAPI_Wrap_AddServerContract(decoded_signed_contract)
+    # should be just one known active server now
+    server.active = [server_contract_id]
+
+
+def create_server_contract():
+    '''
+       Creates a notary contract, and returns the directory where the
+       files were placed.
+
+    '''
+    tmpdir = tempfile.mkdtemp()
+    p = subprocess.Popen(["create_contract"], cwd=tmpdir)
+    p.wait()
+    return tmpdir
+
+
+def start_notary(contract_dir):
+    '''Starts a new notary with the given contract_dir (created using
+       create_contract tool)'''
+    pyopentxs.killall("notary")
+
+    # danger, also kill any opentxs-notary,
+    # since they occupy the same port
+    pyopentxs.killall("opentxs-notary")
+
+    trans_key_arg = "--transport-key=%s/transportKey" % contract_dir
+    sign_key_arg = "--signing-key=%s/signingKey" % contract_dir
+    notary_id_arg = "--notary-id=`cat %s/notaryID`" % contract_dir
+    os.system("notary %s %s %s > opentxs-goatary.log 2>&1 &" %
+              (trans_key_arg, sign_key_arg, notary_id_arg))

--- a/python3/pyopentxs/tests/test_markets.py
+++ b/python3/pyopentxs/tests/test_markets.py
@@ -6,8 +6,16 @@ import opentxs
 from pyopentxs import market
 from pyopentxs import notary
 
-notary.config.read()
-cron_interval = int(int(notary.config.parser['cron']['ms_between_cron_beats']) / 1000 * 1.5)
+cron_interval = None
+
+
+@pytest.fixture(scope="session", autouse=True)
+def speed_up_cron(pytestconfig):
+    if pytestconfig.getoption("--notary-version") == 0:
+        # if old notary, speed up the cron job that picks up new market orders
+        notary.config.read()
+        global cron_interval
+        cron_interval = int(int(notary.config.parser['cron']['ms_between_cron_beats']) / 1000 * 1.5)
 
 
 @pytest.fixture

--- a/python3/pyopentxs/tests/test_nym.py
+++ b/python3/pyopentxs/tests/test_nym.py
@@ -5,6 +5,7 @@ import pytest
 import opentxs
 
 
+@pytest.mark.goatary
 def test_register_nym():
     Nym().register()
 

--- a/python3/runtests.py
+++ b/python3/runtests.py
@@ -1,45 +1,6 @@
 #!/usr/bin/env python3
-import shutil
-import os
-import sys
 import pytest
-import pyopentxs
-from pyopentxs import notary
-import subprocess
-
-
-def create_fresh_ot_config():
-    # this creates fresh data in ../ot-clean-data/.ot
-    if os.path.exists(pyopentxs.config_dir):
-        shutil.rmtree(pyopentxs.config_dir)
-
-    # create a client wallet just for making the server contract
-    os.system("opentxs --dummy-passphrase changepw")
-
-    # create server contract and empty the client side data
-    setup_data = notary.setup(open('../test-data/sample-contracts/localhost.xml'), total_servers=2)
-    p = subprocess.Popen(["opentxs-notary", "--only-init"], stdin=subprocess.PIPE)
-    outs, errs = p.communicate(input=setup_data.getvalue(), timeout=20)
-
-    # set cron interval to shorter than default
-    config_data = notary.config.read()
-    config_data['cron']['ms_between_cron_beats'] = '2500'  # in milliseconds
-    notary.config.write()
-
-
-def fresh_setup():
-    '''opentxs-notary must be on the PATH'''
-
-    create_fresh_ot_config()
-    print("created fresh config, restarting...")
-    notary.restart()
-    print("restarted.")
-    # wait for ready
-    # doesn't seem to be necessary
-    # time.sleep(2)
-
+import sys
 
 if __name__ == "__main__":
-    fresh_setup()
     pytest.main(sys.argv[1:])
-    pyopentxs.cleanup()


### PR DESCRIPTION
Add commandline argument --notary-version, 1=go, 0=c++

tag register_nym test as 'goatary' test group, select with '-m goatary'

kill all notaries of both types before starting fresh one