### PR TITLE
gotary: enable registerInstrumentDefinition test

### DIFF
--- a/python3/pyopentxs/tests/test_client_server.py
+++ b/python3/pyopentxs/tests/test_client_server.py
@@ -14,6 +14,7 @@ from pyopentxs import cash
 
 
 @pytest.mark.parametrize("issue_for_other_nym,expect_success", [[True, False], [False, True]])
+@pytest.mark.goatary
 def test_issue_asset_contract(issue_for_other_nym, expect_success):
     server_id = server.first_active_id()
     nym = Nym().register(server_id)

--- a/test-data/sample-contracts/btc.xml
+++ b/test-data/sample-contracts/btc.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0"?>
-<digitalAssetContract version="2.0">
+<instrumentDefinition version="2.0">
 
 <entity shortname="Satoshi"
 longname="Satoshi Nakamoto" 
@@ -10,7 +10,7 @@ email="info@swedishcoins.net"
 contractUrl="https://swedishcoins.net/contract"
 type="currency"/>
 
-<currency name="Bitcoins" tla="BTC" symbol="BTC" type="decimal" factor="1000" decimal_power="3" fraction="mBTC"/>
+<currency name="Bitcoins" tla="BTC" symbol="BTC" type="decimal" factor="1000" decimalPower="3" fraction="mBTC"/>
 
 <!-- CONDITIONS -->
 
@@ -68,4 +68,4 @@ type="currency"/>
   are done on the basis of strong privacy.
 </condition>
 
-</digitalAssetContract>
+</instrumentDefinition>


### PR DESCRIPTION
Enable registerInstrumentDefinition tests for gotary. Waiting for merging https://github.com/monetas/notary/pull/227